### PR TITLE
Removing the minification-safe process.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Alastair Paragas
+Copyright (c) 2015 Luis Rogelio Hernández López
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,46 +1,32 @@
-# cordova-minify
+# ionic-minify
 
 Cordova hook that uglifies and minifies your app's Javascript files, minifies CSS files, and compresses your image files. It is derived from the work of [Ross Martin's original cordova-uglify](https://github.com/rossmartin/cordova-uglify), with the added image compression and recursive search for your script and stylesheets inside your js/ and css/ folders in www. This DOES NOT compress the assets in your www folder, but rather, on your respective platform's www folders, so your development environment isn't touched, and your apps stay fast and slim!
 
 ## Install
 Install this package inside of your app's root folder with this command.
 ```
-npm install cordova-minify --save-dev
+npm install ionic-minify --save-dev
 ```
-The `--save-dev` flag is important! If you decide to work on another environment, cordova-minify cannot run without the original package and its dependencies! After install, an `after_prepare` folder will be added to your `hooks` folder with the `cordova-minify.js` script in it.
+The `--save-dev` flag is important! If you decide to work on another environment, ionic-minify cannot run without the original package and its dependencies! After install, an `after_prepare` folder will be added to your `hooks` folder with the `ionic-minify.js` script in it.
 
 ## Some valid Cordova development questions...
 
 ### Why not just use Grunt/Yeoman?
-One can use Grunt/Yeoman, though I feel that those are more suited for building web applications/assets, whereas this NPM package is solely developed for Cordova and does not touch your development environment - being the www folder, but rather, only the produced assets. Also, I feel like pulling out Yeoman is an overkill for Cordova, which tends to be a repetitive build process from the start, whereas just pure Grunt configuration takes forever. With cordova-minify, install the plugin, and done!
+One can use Grunt/Yeoman, though I feel that those are more suited for building web applications/assets, whereas this NPM package is solely developed for Cordova and does not touch your development environment - being the www folder, but rather, only the produced assets. Also, I feel like pulling out Yeoman is an overkill for Cordova, which tends to be a repetitive build process from the start, whereas just pure Grunt configuration takes forever. With ionic-minify, install the plugin, and done!
 
 ### Why minify/compress your CSS/Javascript/Images?
 Though you are not improving network speeds considering that assets are not being transmitted over the internet (packaged in your app - duh), I feel that it will help to compress javascript, css, and images to reduce app size and promote performance improvements. App size is a problem for lower-end phones that have limited storage - I personally found this a problem with my Pantech Burst (Android 4.0 - Ice Cream Sandwich).
 
 ## Usage
-Once you have this hook installed it will compress your app's JavaScript and CSS when you run a `cordova prepare <platform>` or `cordova build <platform>` command.  This hook does not change your assets that live in the root www folder; it will uglify the assets that get outputted to the platforms folder after a `prepare` or `build`.
+Once you have this hook installed it will compress your app's JavaScript and CSS when you run a `ionic prepare <platform>` or `ionic build <platform>` command.  This hook does not change your assets that live in the root www folder; it will uglify the assets that get outputted to the platforms folder after a `prepare` or `build`.
 
-By default the hook will uglify the JavaScript, CSS, and images in the `<platform>` `www/js`, `www/css`, and `www/img` of your project [Take a look at this line in the hook to add more folders to be minified - optional](https://github.com/alastairparagas/cordova-minify/blob/master/after_prepare/cordova-minify.js#l111). You can configure the hook to uglify/minify only for a release build, [see here](https://github.com/alastairparagas/cordova-minify/blob/master/after_prepare/cordova-minify.js#l17).
+By default the hook will uglify the JavaScript, CSS, and images in the `<platform>` `www/js`, `www/css`, and `www/img` of your project [Take a look at this line in the hook to add more folders to be minified - optional](https://github.com/Kurtz1993/ionic-minify/blob/master/after_prepare/ionic-minify.js#l111). You can configure the hook to uglify/minify only for a release build, [see here](https://github.com/Kurtz1993/ionic-minify/blob/master/after_prepare/ionic-minify.js#l17).
 
 ## Requirements
-Out of the box this hook requires Cordova 3.3.1-0.4.2 and above but it can work with versions 3.0.0 thru 3.3.0 if you manually indicate the path for the platforms directories on Android and iOS [see here](https://github.com/alastairparagas/cordova-minify/blob/master/after_prepare/cordova-minify.js#l15).  This is because the `CORDOVA_PLATFORMS` environment variable was not added until version 3.3.1-0.4.2 ([see this post by Dan Moore](http://www.mooreds.com/wordpress/archives/1425)).
-
-## Future Development
-* External Config file
-    * Configuration of how image, css, and javascript files are compressed - abstraction away from underlying code, preventing more mess-ups.
-        * https://github.com/kevva/imagemin for image compression
-        * https://github.com/mishoo/UglifyJS2 for js compression/"uglification"
-        * https://github.com/GoalSmashers/clean-css for css cleaning/compression
-    * Folders to include for the whole image/css/javascript compression process
-* HTML compression
-* JSDoc HTML generation for sharing API information amongst developers
-* Additional support for other platforms currently not supported - anything other than Android and iOS
-        
-        
-* Configuration of how image, css, and javascript files are compressed in a configuration file for easier and cleaner implementation, preventing the developer from messing up with underlying code.
+Out of the box this hook requires Cordova 3.3.1-0.4.2 and above but it can work with versions 3.0.0 thru 3.3.0 if you manually indicate the path for the platforms directories on Android and iOS [see here](https://github.com/Kurtz1993/ionic-minify/blob/master/after_prepare/ionic-minify.js#l15).  This is because the `CORDOVA_PLATFORMS` environment variable was not added until version 3.3.1-0.4.2 ([see this post by Dan Moore](http://www.mooreds.com/wordpress/archives/1425)).
 
 ## Quirks:
 * On Linux and OSX: `hooks` folder needs to have permissions modified.  Perform a `chmod -R 755 /hooks` to resolve this issue.
 
 ## License
-[MIT](https://github.com/alastairparagas/cordova-minify/blob/master/LICENSE)
+[MIT](https://github.com/Kurtz1993/ionic-minify/blob/master/LICENSE)

--- a/after_prepare/cordova-minify.js
+++ b/after_prepare/cordova-minify.js
@@ -55,13 +55,13 @@ function compress(file) {
                 },
                 fromString: true    // This will make the uglify work with ngAnnotate.
             });
-            fs.writeFileSync(file, result.code, 'utf8'); // overwrite the original unminified file
+            fs.writeFileSync(file, result.code, 'utf8');
             break;
         case '.css':
             console.log('Minifying CSS File: ' + file);
             var source = fs.readFileSync(file, 'utf8');
             var result = cssMinifier.minify(source);
-            fs.writeFileSync(file, result, 'utf8'); // overwrite the original unminified file
+            fs.writeFileSync(file, result, 'utf8');
             break;
         // Image options https://github.com/imagemin/imagemin
         case '.svg':

--- a/after_prepare/cordova-minify.js
+++ b/after_prepare/cordova-minify.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var UglifyJS = require('uglify-js');
 var CleanCSS = require('clean-css');
+var ngAnnotate = require('ng-annotate');
 var ImageMin = require('imagemin');
 var imagemin = new ImageMin();
 var cssMinifier = new CleanCSS({
@@ -47,18 +48,20 @@ function compress(file) {
     switch(ext) {
         case '.js':
             console.log('Compressing/Uglifying JS File: ' + file);
-            var result = UglifyJS.minify(file, {
+            var res = ngAnnotate(String(fs.readFileSync(file)), { add: true }); // This will make minification-safe not necessary...
+            var result = UglifyJS.minify(res.src, {
                 compress: {
                     drop_console: true
-                }
+                },
+                fromString: true    // This will make the uglify work with ngAnnotate.
             });
-            fs.writeFileSync(file, result.code, 'utf8');
+            fs.writeFileSync(file, result.code, 'utf8'); // overwrite the original unminified file
             break;
         case '.css':
             console.log('Minifying CSS File: ' + file);
             var source = fs.readFileSync(file, 'utf8');
             var result = cssMinifier.minify(source);
-            fs.writeFileSync(file, result, 'utf8');
+            fs.writeFileSync(file, result, 'utf8'); // overwrite the original unminified file
             break;
         // Image options https://github.com/imagemin/imagemin
         case '.svg':
@@ -94,7 +97,6 @@ function compress(file) {
             break;
     }
 }
-
 
 switch (platform) {
     case 'android':

--- a/after_prepare/cordova-minify.js
+++ b/after_prepare/cordova-minify.js
@@ -48,8 +48,8 @@ function compress(file) {
     switch(ext) {
         case '.js':
             console.log('Compressing/Uglifying JS File: ' + file);
-            var res = ngAnnotate(String(fs.readFileSync(file)), { add: true }); // This will make minification-safe not necessary...
-            var result = UglifyJS.minify(res.src, {
+            var js = ngAnnotate(String(fs.readFileSync(file)), { add: true }); // This will make minification-safe not necessary...
+            var result = UglifyJS.minify(js.src, {
                 compress: {
                     drop_console: true
                 },

--- a/after_prepare/ionic-minify.js
+++ b/after_prepare/ionic-minify.js
@@ -15,9 +15,9 @@ var rootDir = process.argv[2];
 var platformPath = path.join(rootDir, 'platforms');
 var platform = process.env.CORDOVA_PLATFORMS;
 var cliCommand = process.env.CORDOVA_CMDLINE;
-var isRelease = true;
+//var isRelease = true;
 
-//var isRelease = (cliCommand.indexOf('--release') > -1); // comment the above line and uncomment this line to turn the hook on only for release
+var isRelease = (cliCommand.indexOf('--release') > -1); // comment the above line and uncomment this line to turn the hook on only for release
 if (!isRelease) {
     return;
 }
@@ -48,20 +48,20 @@ function compress(file) {
     switch(ext) {
         case '.js':
             console.log('Compressing/Uglifying JS File: ' + file);
-            var js = ngAnnotate(String(fs.readFileSync(file)), { add: true }); // This will make minification-safe not necessary...
-            var result = UglifyJS.minify(js.src, {
-                compress: {
-                    drop_console: true
+            var res = ngAnnotate(String(fs.readFileSync(file)), { add: true });
+            var result = UglifyJS.minify(res.src, {
+                compress: { // pass false here if you only want to minify (no obfuscate)
+                    drop_console: true // remove console.* statements (log, warn, etc.)
                 },
-                fromString: true    // This will make the uglify work with ngAnnotate.
+                fromString: true
             });
-            fs.writeFileSync(file, result.code, 'utf8');
+            fs.writeFileSync(file, result.code, 'utf8'); // overwrite the original unminified file
             break;
         case '.css':
             console.log('Minifying CSS File: ' + file);
             var source = fs.readFileSync(file, 'utf8');
             var result = cssMinifier.minify(source);
-            fs.writeFileSync(file, result, 'utf8');
+            fs.writeFileSync(file, result, 'utf8'); // overwrite the original unminified file
             break;
         // Image options https://github.com/imagemin/imagemin
         case '.svg':
@@ -114,4 +114,5 @@ var foldersToProcess = ['js', 'css', 'img'];
 
 foldersToProcess.forEach(function(folder) {
     processFiles(path.join(platformPath, folder));
+
 });

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
-  "name": "cordova-minify",
-  "version": "0.0.15",
-  "description": "Cordova hook that uglifies and minifies your app's Javascript files, minifies CSS files, and compresses your image files.",
-  "homepage": "https://github.com/alastairparagas/cordova-minify",
+  "name": "ionic-minify",
+  "version": "0.1.0",
+  "description": "Cordova hook that minifies your JavaScript and CSS files, and compress images.",
+  "homepage": "https://github.com/Kurtz1993/ionic-minify",
   "keywords": [
     "cordova",
     "uglify",
     "minify",
     "hook",
     "hooks",
-    "cordova-minify"
+    "ionic-minify",
+    "ionic"
   ],
   "dependencies" : {
     "uglify-js": "2.4.x",
@@ -17,15 +18,15 @@
     "ng-annotate": "0.15.4",
     "imagemin": "3.1.x"
   },
-  "author": "Alastair Paragas",
+  "author": "Luis Rogelio Hernández López",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/alastairparagas/cordova-minify/issues"
+    "url": "https://github.com/Kurtz1993/ionic-minifyissues"
   },
   "readmeFilename": "README.md",
   "repository" : {
     "type": "git",
-    "url": "https://github.com/alastairparagas/cordova-minify.git"
+    "url": "https://github.com/Kurtz1993/ionic-minify.git"
   },
   "scripts": {
     "postinstall": "node scripts/install.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies" : {
     "uglify-js": "2.4.x",
     "clean-css": "2.2.x",
+    "ng-annotate": "0.15.4",
     "imagemin": "3.1.x"
   },
   "author": "Alastair Paragas",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -10,22 +10,19 @@ var paths = [ path.join(cwd, '..', '..', 'hooks'), path.join(cwd, '..', '..', 'h
 // If paths do not exist, make them.
 for(var pathIndex in paths) {
 	if(!fs.existsSync(paths[pathIndex])) {
-		console.log('Creating directory: ', paths[pathIndex])
+		console.log('Creating directory: ', paths[pathIndex]);
 		fs.mkdirSync(paths[pathIndex]);
 	}	
 }
 
 // Absolute Location of our cordova-minify.js file
-var minifyFilePath = path.join(cwd, 'after_prepare', 'cordova-minify.js');
+var minifyFilePath = path.join(cwd, 'after_prepare', 'ionic-minify.js');
 
 // Copy our minify script to the cordova hooks folder.
 var minifyFile = fs.readFileSync(minifyFilePath);
-console.log('Grabbing Minifier File from minify package in node_modules');
 var minifyFileNewPath = path.join(paths[1], 'minify.js');
-console.log('Copying Minifier File to Cordova hooks/after_prepare');
+console.log('Copying minifier file to Cordova hooks/after_prepare...');
 fs.writeFileSync(minifyFileNewPath, minifyFile);
 
-console.log('Finished set-up! Your JS, CSS, and img files will be automatically compressed, and your JS files uglified!');
-console.log();
-console.log('cordova-minify - developed by Alastair Paragas@2014, Stela Inc. cordova-minify is an open-source/MIT project');
-console.log('Any issues? Do not hesitate to post bugs and issues to https://github.com/alastairparagas/cordova-minify');
+console.log('Finished installing. Try running ionic build --release \n');
+console.log('You can check the script inside hooks/after_prepare so you can minify while developing too!');

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -13,4 +13,4 @@ fs.unlink(minifyJsPath, function(error){
         console.log('Uninstalled hooks: ', minifyJsPath);
     }
 });
-console.log('Uninstalled cordova-minify. We are sad to see you go! See you soon!');
+console.log('Uninstalled successfuly!');


### PR DESCRIPTION
With this changes the AngularJS minification-safe process won't be necessary. Just run the hook and it'll be uglify/minifying your code without the need of adding extra stuff.
Tested on a production application ;)
